### PR TITLE
add save+restore scrollbar positions (fix #63)

### DIFF
--- a/js/content-script.js
+++ b/js/content-script.js
@@ -559,10 +559,17 @@ function restoreVideo() {
       node.removeAttribute('mvclass');
     }
   }
+
+  if(mvImpl.scrollPosition) {
+    window.scrollTo(mvImpl.scrollPosition.x, mvImpl.scrollPosition.y);
+  }
 };
 
 function maximizeVideo(selectedNode, chain = []) {
   const _chain = [...chain]
+
+  mvImpl.scrollPosition = { x: window.scrollX, y: window.scrollY };
+
   const hideAllSibling = (node) => {
     if(node === mvImpl.mainNode) {
       node.setAttribute('mvclass', 'core');


### PR DESCRIPTION
before maximizing video, save the scrollbar positions
after restoring video, restore the scrollbar positions

test on a site that makes you scroll down before showing a video element (*cough* 4chan)